### PR TITLE
cmake_minimum_required == 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 ###################################################################################################
 ## These variables are passed to oatpp-module-install.cmake script


### PR DESCRIPTION
CMake 4.0 removed compatibility to CMake verssions < 3.5. Eyeball check says upping to 3.5 is fine.